### PR TITLE
readme: update links for basedmypy

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,16 @@ https://github.com/mypyc/mypy_mypyc-wheels/actions
 
 You can use pip to install these wheels like so:
 ```bash
-pip install --upgrade --find-links https://github.com/mypyc/mypy_mypyc-wheels/releases mypy
-# or if you need a specific version
-pip install --upgrade --find-links https://github.com/mypyc/mypy_mypyc-wheels/releases mypy==0.990+dev.4ccfca162184ddbc9139f7a3abd72ce7139a2ec3
+pip install --upgrade --find-links https://github.com/mypyc/mypy_mypyc-wheels/releases/ mypy
+# If you need a specific version, specify the url as follows
+pip install --upgrade --find-links https://github.com/mypyc/mypy_mypyc-wheels/releases/expanded_assets/v0.990+dev.4ccfca162184ddbc9139f7a3abd72ce7139a2ec3 mypy
+```
+
+Unfortunately, these options may not work, and could instead install a source dist or the wrong version.
+In this case you will need to manually select the wheel you wish to install: navigate to the release page and copy
+the url of the correct wheel.
+```bash
+pip install https://github.com/mypyc/mypy_mypyc-wheels/releases/download/v0.990%2Bdev.4ccfca162184ddbc9139f7a3abd72ce7139a2ec3/mypy-0.990+dev.4ccfca162184ddbc9139f7a3abd72ce7139a2ec3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
 ```
 
 ##  Building locally


### PR DESCRIPTION
This was correct previously, but there was a change upstream, so I'm redoing it